### PR TITLE
Update archive to temp location for now

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -1,6 +1,6 @@
 [archive]
 build_output_dir = 'Built'
-archive_location = '\\us-aus-hilbuild\builds\niveristandadd-ons\custom devices\chassis_timesync_custom_device'
+archive_location = '\\nirvana\temp\vs_cds\chassis_timesync_custom_device'
 
 [projects.cd]
 path = 'Source\Chassis TimeSync Custom Device.lvproj'


### PR DESCRIPTION
All other custom devices currently archive to a temporary location. Do this for this custom device also, instead of overwriting what is on the SE server with our new builds.