### PR TITLE
Revert changes to custom device xml made in cb7a0537d760aa0f045108f802ba75ce145668e0

### DIFF
--- a/Source/Timing and Sync Chassis TimeSync.xml
+++ b/Source/Timing and Sync Chassis TimeSync.xml
@@ -50,6 +50,58 @@
 				<Path>Timing and Sync\Chassis TimeSync\Chassis TimeSync Configuration.llb\ActionVIOnCompile.vi</Path>
 			</ActionVIOnCompile>
     </Page>
+	<Page>
+		<Name>
+			<eng>Channel (delete protected)</eng>
+			<loc>Channel (delete protected)</loc>
+		</Name>
+		<DisallowRenaming>true</DisallowRenaming>
+		<DeleteProtection>true</DeleteProtection>
+		<GUID>C9C36D38-F811-822C-0C95-B5EFD5033E75</GUID>
+		<Glyph>
+			<Type>To Application Data Dir</Type>
+			<Path>System Explorer\Glyphs\default fpga channel.png</Path>
+		</Glyph>
+		<Item2Launch>
+			<Type>Absolute</Type>
+			<Path>System UI VIs\Custom Device\Custom Device Channel.vi</Path>
+		</Item2Launch>
+		<RunTimeMenu />
+		<Help>
+			<Item2Launch>
+				<Type>To Base</Type>
+				<Path>Veristand.chm\Custom_Devices_SE.html</Path>
+			</Item2Launch>
+			<FileType>chm</FileType>
+		</Help>
+	</Page>
+	
+	<Page>
+		<Name>
+			<eng>Section (delete protected)</eng>
+			<loc>Section (delete protected)</loc>
+		</Name>
+		<DisallowRenaming>true</DisallowRenaming>
+		<DeleteProtection>true</DeleteProtection>
+		<GUID>297B72C6-21C2-EA0B-6E7C-23F9EC8798A9</GUID>
+		<Glyph>
+			<Type>To Application Data Dir</Type>
+			<Path>System Explorer\Glyphs\default fpga category.png</Path>
+		</Glyph>
+		<Item2Launch>
+			<Type>Absolute</Type>
+			<Path>System UI VIs\Custom Device\Custom Device Section.vi</Path>
+		</Item2Launch>
+		<RunTimeMenu>
+		</RunTimeMenu>
+		<Help>
+			<Item2Launch>
+				<Type>To Base</Type>
+				<Path>Veristand.chm\Custom_Devices_SE.html</Path>
+			</Item2Launch>
+			<FileType>chm</FileType>
+		</Help>
+	</Page>
   </Pages>
   <CustomXML>
     <Dummy></Dummy>


### PR DESCRIPTION
[x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-chassis-timesync-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The custom device XML references pages which are provided by VeriStand,
which are needed at runtime. These VIs are not included with the custom
device, and so the pages were erroneously removed from the xml as unused.

This is causing a failure at system-definition configuration time.

Special case logic will need to be added to the connector pane
validation to ignore VIs provided by VeriStand.

### Why should this Pull Request be merged?

Fixes system definition configuration which is currently broken.

### What testing has been done?

Loaded a system definition with the fix and confirmed I could view the channels properly.
