### PR TITLE
Put custom device under National Instruments item

### DIFF
--- a/Source/Timing and Sync Chassis TimeSync.xml
+++ b/Source/Timing and Sync Chassis TimeSync.xml
@@ -2,8 +2,8 @@
 <CustomDevice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Custom Device.xsd">
 <XSDVersion Major="2010" Minor="0" Fix="0" Build="0" />
   <AddMenu>
-    <eng>Chassis TimeSync</eng>
-    <loc>Chassis TimeSync</loc>
+    <eng>National Instruments::Chassis TimeSync</eng>
+    <loc>National Instruments::Chassis TimeSync</loc>
   </AddMenu>
   <Version>1.1.0</Version>
   <Type>Asynchronous Timing and Sync</Type>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-chassis-timesync-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Moves the Chassis TimeSync custom device from the top level to the National Instruments menu item.

![image](https://user-images.githubusercontent.com/573497/48161255-b50cea00-e29f-11e8-8b3a-65d9da89bc31.png)

### Why should this Pull Request be merged?

The 10MHz PLL custom device lives at this location; the Scan Engine EtherCAT and Engine Simulation Toolkit Custom Devices are also under the National Instruments namespace in the normal custom device menu item. This makes this custom device more consistent with other custom devices produced by NI.

### What testing has been done?

Built the custom device and confirmed it appeared in the new location.
