### PR TITLE
Bump custom device version to 2.0.0

### DIFF
--- a/Source/Timing and Sync Chassis TimeSync.xml
+++ b/Source/Timing and Sync Chassis TimeSync.xml
@@ -5,7 +5,7 @@
     <eng>National Instruments::Chassis TimeSync</eng>
     <loc>National Instruments::Chassis TimeSync</loc>
   </AddMenu>
-  <Version>1.1.0</Version>
+  <Version>2.0.0</Version>
   <Type>Asynchronous Timing and Sync</Type>
   <MaxOccurrence>1</MaxOccurrence>
   <MainPageGUID>85FE1586-82E1-A7AD-798B-5599EFFC50EE</MainPageGUID>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-chassis-timesync-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This updates the custom device version to reflect the change in functionality made in commit 6f6b04b766a5e88e164983ad94ca9d17ae2853af.

### Why should this Pull Request be merged?

We never bumped the CD version after making the original change.

### What testing has been done?

Ran [deployment tests for PharLap](https://github.com/ni/niveristand-chassis-timesync-custom-device/files/2600254/2018_11_20_08_59_10.VI.Tester.txt), as well as the [unit tests](https://github.com/ni/niveristand-chassis-timesync-custom-device/files/2600262/2018_11_20_09_00_32.VI.Tester.txt) with the 2018 stack.

